### PR TITLE
fix ref for ignoreAccents

### DIFF
--- a/client/src/containers/UserAnswer.js
+++ b/client/src/containers/UserAnswer.js
@@ -18,7 +18,7 @@ const UserAnswer = (props) => {
 					if (!input.current.value.trim()) {
 						return;
 					}
-					dispatch(submitAnswer(input.current.value, ignoreAccents.checked));
+					dispatch(submitAnswer(input.current.value, ignoreAccents.current.checked));
 					input.current.value = '';
 				}
 				}


### PR DESCRIPTION
The ref API changed. This simple fix gets ignoreAccents to work again.

Before
<img width="778" alt="Screen Shot 2020-03-16 at 10 24 42 PM" src="https://user-images.githubusercontent.com/79715/76824874-a9a3ca00-67d5-11ea-87c2-9c2b5a0bbb9e.png">
After
<img width="744" alt="Screen Shot 2020-03-16 at 10 25 30 PM" src="https://user-images.githubusercontent.com/79715/76824880-b0324180-67d5-11ea-8efe-ba4381d1f852.png">

