### PR TITLE
Add sessions to state

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12382,6 +12382,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
+    "reselect": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+      "integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
+    },
     "resolve": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.2.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,8 @@
     "redux-logger": "^3.0.6",
     "redux-persist": "^6.0.0",
     "redux-thunk": "^2.3.0",
-    "redux-undo": "^1.0.0"
+    "redux-undo": "^1.0.0",
+    "reselect": "^4.0.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -3,31 +3,24 @@ import { connect } from 'react-redux';
 import { useRoutes } from 'hookrouter';
 
 import QuizPage from './components/QuizPage';
+import {getIsFirstQuestion, getIsLastQuestion, getIsSessionOver, getIsSessionEnabled} from './selectors/currentSession';
 
-const routes = (props) => ({
+const routes = (props) => { 
+
+	return ({
 	'/': () => (
 		<QuizPage
-			type={props.type}
-			filters={props.filters}
-			user={props.user}
-			quiz={props.quiz}
-			dispatch={props.dispatch}
-			currentSession = {props.currentSession}
+			{... props}
 			headerText="Yo practico, tú practicas, nosotros practicamos"
 		/>
 	),
 	'/numbers': () => (
 		<QuizPage
-			type={props.type}
-			filters={props.filters}
-			user={props.user}
-			quiz={props.quiz}
-			dispatch={props.dispatch}
-			currentSession = {props.currentSession}
+			{... props}
 			headerText="Cuenta conmigo. Uno, dos, tres ..."
 		/>
 	),
-});
+})};
 
 const App = (props) => {
 	const routeResult = useRoutes(routes(props));
@@ -39,7 +32,12 @@ const mapStateToProps = (state) => ({
 	type: state.quiz.type,
 	quiz: state.quiz,
 	user: state.user,
-	currentSession: state.currentSession,
+	session: {isSessionOver: getIsSessionOver(state),
+		getIsFirstQuestion: getIsFirstQuestion(state),
+		isLastQuestion: getIsLastQuestion(state),
+		isSessionEnabled: getIsSessionEnabled(state),
+		sessionQuestionNum: state.currentSession.sessionQuestionNum,
+		sessionLength: state.currentSession.sessionLength}
 });
 
 export default connect(mapStateToProps)(App);

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -33,8 +33,8 @@ const mapStateToProps = (state) => ({
 	quiz: state.quiz,
 	user: state.user,
 	session: {isSessionOver: getIsSessionOver(state),
-		getIsFirstQuestion: getIsFirstQuestion(state),
-		isLastQuestion: getIsLastQuestion(state),
+		isFirstQuestionInSession: getIsFirstQuestion(state),
+		isLastQuestionInSession: getIsLastQuestion(state),
 		isSessionEnabled: getIsSessionEnabled(state),
 		sessionQuestionNum: state.currentSession.sessionQuestionNum,
 		sessionLength: state.currentSession.sessionLength}

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -12,6 +12,7 @@ const routes = (props) => ({
 			user={props.user}
 			quiz={props.quiz}
 			dispatch={props.dispatch}
+			currentSession = {props.currentSession}
 			headerText="Yo practico, tú practicas, nosotros practicamos"
 		/>
 	),
@@ -22,6 +23,7 @@ const routes = (props) => ({
 			user={props.user}
 			quiz={props.quiz}
 			dispatch={props.dispatch}
+			currentSession = {props.currentSession}
 			headerText="Cuenta conmigo. Uno, dos, tres ..."
 		/>
 	),
@@ -37,6 +39,7 @@ const mapStateToProps = (state) => ({
 	type: state.quiz.type,
 	quiz: state.quiz,
 	user: state.user,
+	currentSession: state.currentSession,
 });
 
 export default connect(mapStateToProps)(App);

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -107,7 +107,6 @@ export function loadQuizWithParameters(quizType, params ) {
 export function setSessionLength(sessionLength) {
 	return (dispatch) => {
 		dispatch({type: SET_SESSION_LENGTH, sessionLength});
-		dispatch({type: START_SESSION, sessionLength})
 	}
 }
 

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -14,9 +14,13 @@ export const LOAD_QUIZ_ERROR = 'LOAD_QUIZ_ERROR';
 
 export const SET_VERBSET = 'SET_VERBSET';
 
+export const SET_SESSION_LENGTH = 'SET_SESSION_LENGTH';
+
 export const SUBMIT_ANSWER = 'SUBMIT_ANSWER';
 
 export const TOGGLE_FOCUS = 'TOGGLE_FOCUS';
+
+export const START_SESSION = 'START_SESSION'
 
 /*
  * action creators
@@ -97,6 +101,18 @@ export function loadQuizWithParameters(quizType, params ) {
 			console.error('request failed', error);
 		});
 	};
+}
+
+export function setSessionLength(sessionLength) {
+	return (dispatch) => {
+		dispatch({type: SET_SESSION_LENGTH, sessionLength})
+	}
+}
+
+export function startSession(sessionLength) {
+	return (dispatch) => {
+		dispatch({type: SET_SESSION_LENGTH, sessionLength})
+	}
 }
 
 export function toggleFocus() {

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -20,7 +20,8 @@ export const SUBMIT_ANSWER = 'SUBMIT_ANSWER';
 
 export const TOGGLE_FOCUS = 'TOGGLE_FOCUS';
 
-export const START_SESSION = 'START_SESSION'
+export const START_SESSION = 'START_SESSION';
+export const END_SESSION = 'END_SESSION';
 
 /*
  * action creators
@@ -113,6 +114,12 @@ export function setSessionLength(sessionLength) {
 export function startSession(sessionLength) {
 	return (dispatch) => {
 		dispatch({type: SET_SESSION_LENGTH, sessionLength})
+	}
+}
+
+export function endSession() {
+	return (dispatch) => {
+		dispatch({type: END_SESSION});
 	}
 }
 

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -105,7 +105,8 @@ export function loadQuizWithParameters(quizType, params ) {
 
 export function setSessionLength(sessionLength) {
 	return (dispatch) => {
-		dispatch({type: SET_SESSION_LENGTH, sessionLength})
+		dispatch({type: SET_SESSION_LENGTH, sessionLength});
+		dispatch({type: START_SESSION, sessionLength})
 	}
 }
 

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -111,9 +111,9 @@ export function setSessionLength(sessionLength) {
 	}
 }
 
-export function startSession(sessionLength) {
+export function startSession() {
 	return (dispatch) => {
-		dispatch({type: SET_SESSION_LENGTH, sessionLength})
+		dispatch({type: START_SESSION})
 	}
 }
 

--- a/client/src/components/ControlledCard.js
+++ b/client/src/components/ControlledCard.js
@@ -4,9 +4,8 @@ import PropTypes from 'prop-types';
 import NumbersQuizCard from './NumbersQuizCard';
 import VerbQuizCard from './VerbQuizCard';
 import { flipCard } from '../actions';
-import SessionEndCard from './SessionEndCard';
 
-const ControlledCard = ({dispatch, quiz, user, filters, type, sessionEnd}) => {
+const ControlledCard = ({dispatch, quiz, user, filters, type, sessionOver}) => {
 	const cardRef = useRef();
 	useEffect(() => {
 		if (quiz.focus === 'card' && cardRef) {
@@ -15,13 +14,10 @@ const ControlledCard = ({dispatch, quiz, user, filters, type, sessionEnd}) => {
 	}, [type, dispatch, quiz.focus]);
 
 	let quizCard;
-	if (sessionEnd === true) {
-		quizCard = React.createElement(SessionEndCard)
-	}
-	else if (type === 'numbers') {
-		quizCard = React.createElement(NumbersQuizCard, {...quiz, questionNum: user.questionNum})
+	if (type === 'numbers') {
+		quizCard = React.createElement(NumbersQuizCard, {...quiz, questionNum: user.questionNum, sessionOver})
 	} else {
-		quizCard = React.createElement(VerbQuizCard, {...quiz, questionNum: user.questionNum})
+		quizCard = React.createElement(VerbQuizCard, {...quiz, questionNum: user.questionNum, sessionOver})
 	}
 	return (
 		<div
@@ -40,11 +36,12 @@ ControlledCard.propTypes = {
 	quiz: PropTypes.object.isRequired,
 	user: PropTypes.object.isRequired,
 	filters: PropTypes.object.isRequired,
-	sessionEnd: PropTypes.bool,
+	sessionOver: PropTypes.bool.isRequired
 };
 
-ControlledCard.defaultProps = {
-	sessionEnd: false
+ControlledCard.defaultProp = {
+	sessionOver: false,
 }
+
 
 export default ControlledCard;

--- a/client/src/components/ControlledCard.js
+++ b/client/src/components/ControlledCard.js
@@ -5,7 +5,7 @@ import NumbersQuizCard from './NumbersQuizCard';
 import VerbQuizCard from './VerbQuizCard';
 import { flipCard } from '../actions';
 
-const ControlledCard = ({dispatch, quiz, user, filters, type, sessionOver}) => {
+const ControlledCard = ({dispatch, quiz, user, filters, type, session: {isSessionEnabled, sessionQuestionNum, sessionLength, isSessionOver}}) => {
 	const cardRef = useRef();
 	useEffect(() => {
 		if (quiz.focus === 'card' && cardRef) {
@@ -13,11 +13,13 @@ const ControlledCard = ({dispatch, quiz, user, filters, type, sessionOver}) => {
 		}
 	}, [type, dispatch, quiz.focus]);
 
+	const questionNum = isSessionEnabled === true ? `${sessionQuestionNum} / ${sessionLength}` : user.questionNum;
+
 	let quizCard;
 	if (type === 'numbers') {
-		quizCard = React.createElement(NumbersQuizCard, {...quiz, questionNum: user.questionNum, sessionOver})
+		quizCard = React.createElement(NumbersQuizCard, {...quiz, questionNum: questionNum, isSessionOver})
 	} else {
-		quizCard = React.createElement(VerbQuizCard, {...quiz, questionNum: user.questionNum, sessionOver})
+		quizCard = React.createElement(VerbQuizCard, {...quiz, questionNum: questionNum, isSessionOver})
 	}
 	return (
 		<div
@@ -36,11 +38,16 @@ ControlledCard.propTypes = {
 	quiz: PropTypes.object.isRequired,
 	user: PropTypes.object.isRequired,
 	filters: PropTypes.object.isRequired,
-	sessionOver: PropTypes.bool.isRequired
+	session: PropTypes.shape({
+		isSessionOver: PropTypes.bool,
+		isSessionEnabled: PropTypes.bool,
+		sessionQuestionNum: PropTypes.number,
+		sessionLength: PropTypes.number,
+	}).isRequired,
 };
 
 ControlledCard.defaultProp = {
-	sessionOver: false,
+	isSessionOver: false,
 }
 
 

--- a/client/src/components/ControlledCard.js
+++ b/client/src/components/ControlledCard.js
@@ -4,8 +4,9 @@ import PropTypes from 'prop-types';
 import NumbersQuizCard from './NumbersQuizCard';
 import VerbQuizCard from './VerbQuizCard';
 import { flipCard } from '../actions';
+import SessionEndCard from './SessionEndCard';
 
-const ControlledCard = ({dispatch, quiz, user, filters, type}) => {
+const ControlledCard = ({dispatch, quiz, user, filters, type, sessionEnd}) => {
 	const cardRef = useRef();
 	useEffect(() => {
 		if (quiz.focus === 'card' && cardRef) {
@@ -14,7 +15,10 @@ const ControlledCard = ({dispatch, quiz, user, filters, type}) => {
 	}, [type, dispatch, quiz.focus]);
 
 	let quizCard;
-	if (type === 'numbers') {
+	if (sessionEnd === true) {
+		quizCard = React.createElement(SessionEndCard)
+	}
+	else if (type === 'numbers') {
 		quizCard = React.createElement(NumbersQuizCard, {...quiz, questionNum: user.questionNum})
 	} else {
 		quizCard = React.createElement(VerbQuizCard, {...quiz, questionNum: user.questionNum})
@@ -36,6 +40,11 @@ ControlledCard.propTypes = {
 	quiz: PropTypes.object.isRequired,
 	user: PropTypes.object.isRequired,
 	filters: PropTypes.object.isRequired,
+	sessionEnd: PropTypes.bool,
 };
+
+ControlledCard.defaultProps = {
+	sessionEnd: false
+}
 
 export default ControlledCard;

--- a/client/src/components/Controls.js
+++ b/client/src/components/Controls.js
@@ -3,12 +3,12 @@ import PropTypes from 'prop-types';
 import { Button } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-const Controls = ({ onNextClick, onPrevClick, onShowClick, showAnswer }) => {
+const Controls = ({ onNextClick, onPrevClick, onShowClick, showAnswer, session: {isFirstQuestionInSession} }) => {
 	const showButtonText = showAnswer ? 'See Question' : 'See Answer';
 	return (
 		<div className="control-buttons">
 			<div>
-				<Button variant="success" onClick={onPrevClick}>
+				<Button variant="success" onClick={onPrevClick} disabled={isFirstQuestionInSession}>
 					<FontAwesomeIcon name="back-button" icon="chevron-left" fixedWidth /> Back
 				</Button>
 				<Button variant="success" onClick={onNextClick}>Next

--- a/client/src/components/CustomVerbOptions.js
+++ b/client/src/components/CustomVerbOptions.js
@@ -3,6 +3,7 @@ import { Card, Form, Tabs, Tab } from 'react-bootstrap';
 
 import FilterCheckbox from '../containers/FilterCheckbox';
 import MoodTrigger from '../containers/MoodTrigger';
+import SessionLengthChoices from '../containers/SessionLengthChoices';
 import VerbSetSelector from '../containers/VerbSetSelector';
 
 function CustomVerbOptions() {
@@ -17,6 +18,7 @@ function CustomVerbOptions() {
 						disabled
 						inline
 					/>
+					<SessionLengthChoices/>
 				</Card.Body>
 			</Card>
 			<Tabs defaultActiveKey={1} id="customized-tabs">

--- a/client/src/components/QuestionCard.js
+++ b/client/src/components/QuestionCard.js
@@ -17,7 +17,7 @@ function QuestionCard({ question, questionNum }) {
 
 QuestionCard.propTypes = {
     question: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
-    questionNum: PropTypes.number.isRequired,
+    questionNum: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
 QuestionCard.defaultProps = {

--- a/client/src/components/QuizCard.js
+++ b/client/src/components/QuizCard.js
@@ -22,7 +22,7 @@ function shouldShowAnswerCard(props) {
  * Determines what card should be shown based on quiz state
  */
 function QuizCard(props) {
-	if (props.sessionOver === true){
+	if (props.isSessionOver === true){
 		return(<SessionEndCard></SessionEndCard>);
 	}
 	else if (shouldShowFeedbackCard(props)) {
@@ -61,7 +61,7 @@ QuizCard.propTypes = {
 	submittedAnswer: PropTypes.string,
 	text: PropTypes.string, //message
 	questionNum: PropTypes.number,
-	sessionOver: PropTypes.bool.isRequired
+	isSessionOver: PropTypes.bool.isRequired
 };
 
 QuizCard.defaultProps = {
@@ -74,7 +74,7 @@ QuizCard.defaultProps = {
 	correctAnswer: '',
 	text: '',
 	questionNum: 0,
-	sessionOver: false
+	isSessionOver: false
 };
 
 export default QuizCard;

--- a/client/src/components/QuizCard.js
+++ b/client/src/components/QuizCard.js
@@ -17,6 +17,10 @@ function shouldShowAnswerCard(props) {
 	return props.question && props.showAnswer === true;
 }
 
+function shouldShowSessionEndCard(props) {
+
+}
+
 /**
  * Determines what card should be shown based on quiz state
  */

--- a/client/src/components/QuizCard.js
+++ b/client/src/components/QuizCard.js
@@ -17,10 +17,6 @@ function shouldShowAnswerCard(props) {
 	return props.question && props.showAnswer === true;
 }
 
-function shouldShowSessionEndCard(props) {
-
-}
-
 /**
  * Determines what card should be shown based on quiz state
  */

--- a/client/src/components/QuizCard.js
+++ b/client/src/components/QuizCard.js
@@ -4,6 +4,7 @@ import QuestionCard from './QuestionCard'
 import FeedbackCard from './FeedbackCard';
 import AnswerCard from './AnswerCard';
 import MessageCard from './MessageCard';
+import SessionEndCard from './SessionEndCard';
 
 function shouldShowFeedbackCard(props) {
 	return props.hasSubmittedAnswer && props.question;
@@ -21,7 +22,10 @@ function shouldShowAnswerCard(props) {
  * Determines what card should be shown based on quiz state
  */
 function QuizCard(props) {
-	if (shouldShowFeedbackCard(props)) {
+	if (props.sessionOver === true){
+		return(<SessionEndCard></SessionEndCard>);
+	}
+	else if (shouldShowFeedbackCard(props)) {
 		return (
 			<FeedbackCard
 				isCorrect={props.isCorrect}
@@ -41,6 +45,7 @@ function QuizCard(props) {
 			/>
 		);
 	}
+
 	return (
 		<MessageCard msg={props.text} />
 	);
@@ -56,6 +61,7 @@ QuizCard.propTypes = {
 	submittedAnswer: PropTypes.string,
 	text: PropTypes.string, //message
 	questionNum: PropTypes.number,
+	sessionOver: PropTypes.bool.isRequired
 };
 
 QuizCard.defaultProps = {
@@ -68,6 +74,7 @@ QuizCard.defaultProps = {
 	correctAnswer: '',
 	text: '',
 	questionNum: 0,
+	sessionOver: false
 };
 
 export default QuizCard;

--- a/client/src/components/QuizCard.js
+++ b/client/src/components/QuizCard.js
@@ -60,7 +60,7 @@ QuizCard.propTypes = {
 	showAnswer: PropTypes.bool,
 	submittedAnswer: PropTypes.string,
 	text: PropTypes.string, //message
-	questionNum: PropTypes.number,
+	questionNum: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 	isSessionOver: PropTypes.bool.isRequired
 };
 

--- a/client/src/components/QuizPage.js
+++ b/client/src/components/QuizPage.js
@@ -14,12 +14,13 @@ import UserAnswer from '../containers/UserAnswer';
 import { loadQuizWithParameters, switchQuiz } from '../actions';
 
 import './QuizPage.css';
+import { getIsSessionEnabled } from '../selectors/currentSession';
 
 /*
 *   Organizes Layout for Quiz UI
 */
 const QuizPage = (props) => {
-	const { type, headerText, filters, dispatch, quiz, user, currentSession } = props;
+	const { type, headerText, filters, dispatch, quiz, user, session } = props;
 	const path = usePath();
 	const quizType = path.slice(1) || 'verbs';
 	useEffect(() => {
@@ -41,10 +42,10 @@ const QuizPage = (props) => {
 							<Row className="show-grid">
 								<Col md={7}>
 									<Row className="show-grid">
-										<ControlledCard type={quizType} filters={filters} quiz={quiz} user={user} dispatch={dispatch} sessionOver={currentSession.sessionOver} />
+										<ControlledCard type={quizType} filters={filters} quiz={quiz} user={user} dispatch={dispatch} session={session} />
 									</Row>
 									<Row className="ctrl">
-										<LinkControls filters={filters} isLastQuestion={currentSession.isLastQuestion} />
+										<LinkControls filters={filters} session={session} />
 									</Row>
 									<Row className="ctrl">
 										<UserAnswer />
@@ -73,7 +74,15 @@ QuizPage.propTypes = {
 	user: PropTypes.object.isRequired,
 	filters: PropTypes.object.isRequired,
 	headerText: PropTypes.string.isRequired,
-	currentSession: PropTypes.object.isRequired,
+	
+	session: PropTypes.shape({
+		isSessionOver: PropTypes.bool,
+		isSessionEnabled: PropTypes.bool,
+		sessionQuestionNum: PropTypes.number,
+		sessionLength: PropTypes.number,
+		isLastQuestionInSession: PropTypes.bool.isRequired,
+		isFirstQuestionInSession: PropTypes.bool.isRequired,
+	}).isRequired
 };
 
 export default QuizPage;

--- a/client/src/components/QuizPage.js
+++ b/client/src/components/QuizPage.js
@@ -12,9 +12,7 @@ import KeyboardListener from './KeyboardListener';
 import LinkControls from '../containers/LinkControls';
 import UserAnswer from '../containers/UserAnswer';
 import { loadQuizWithParameters, switchQuiz, startSession } from '../actions';
-
 import './QuizPage.css';
-import { getIsSessionEnabled } from '../selectors/currentSession';
 
 /*
 *   Organizes Layout for Quiz UI
@@ -23,8 +21,9 @@ const QuizPage = (props) => {
 	const { type, headerText, filters, dispatch, quiz, user, session } = props;
 	const path = usePath();
 	const quizType = path.slice(1) || 'verbs';
+	const {isSessionEnabled} = session;
 	useEffect(() => {
-		if (session.isSessionEnabled) {
+		if (isSessionEnabled) {
 			dispatch(startSession());
 		}
 		if (quizType !== type) {
@@ -32,7 +31,7 @@ const QuizPage = (props) => {
 		} else {
 			dispatch(loadQuizWithParameters(quizType, filters));
 		}
-	}, [quizType, type, filters, dispatch]);
+	}, [quizType, type, filters, dispatch, isSessionEnabled]);
 
 	const customOptions = (quizType === 'numbers') ? <CustomNumberOptions /> : <CustomVerbOptions />
 	return (

--- a/client/src/components/QuizPage.js
+++ b/client/src/components/QuizPage.js
@@ -11,7 +11,7 @@ import ControlledCard from './ControlledCard';
 import KeyboardListener from './KeyboardListener';
 import LinkControls from '../containers/LinkControls';
 import UserAnswer from '../containers/UserAnswer';
-import { loadQuizWithParameters, switchQuiz } from '../actions';
+import { loadQuizWithParameters, switchQuiz, startSession } from '../actions';
 
 import './QuizPage.css';
 import { getIsSessionEnabled } from '../selectors/currentSession';
@@ -24,6 +24,9 @@ const QuizPage = (props) => {
 	const path = usePath();
 	const quizType = path.slice(1) || 'verbs';
 	useEffect(() => {
+		if (session.isSessionEnabled) {
+			dispatch(startSession());
+		}
 		if (quizType !== type) {
 			dispatch(switchQuiz(quizType));
 		} else {

--- a/client/src/components/QuizPage.js
+++ b/client/src/components/QuizPage.js
@@ -29,7 +29,6 @@ const QuizPage = (props) => {
 			dispatch(loadQuizWithParameters(quizType, filters));
 		}
 	}, [quizType, type, filters, dispatch]);
-	const sessionEnd = currentSession.questionsRemaining === 0
 
 	const customOptions = (quizType === 'numbers') ? <CustomNumberOptions /> : <CustomVerbOptions />
 	return (
@@ -42,10 +41,10 @@ const QuizPage = (props) => {
 							<Row className="show-grid">
 								<Col md={7}>
 									<Row className="show-grid">
-										<ControlledCard type={quizType} filters={filters} quiz={quiz} user={user} dispatch={dispatch} sessionEnd={sessionEnd} />
+										<ControlledCard type={quizType} filters={filters} quiz={quiz} user={user} dispatch={dispatch} sessionOver={currentSession.sessionOver} />
 									</Row>
 									<Row className="ctrl">
-										<LinkControls filters={filters} />
+										<LinkControls filters={filters} isLastQuestion={currentSession.isLastQuestion} />
 									</Row>
 									<Row className="ctrl">
 										<UserAnswer />

--- a/client/src/components/QuizPage.js
+++ b/client/src/components/QuizPage.js
@@ -19,17 +19,17 @@ import './QuizPage.css';
 *   Organizes Layout for Quiz UI
 */
 const QuizPage = (props) => {
-	const { type, headerText, filters, dispatch, quiz, user } = props;
+	const { type, headerText, filters, dispatch, quiz, user, currentSession } = props;
 	const path = usePath();
 	const quizType = path.slice(1) || 'verbs';
 	useEffect(() => {
-		console.log('useEffect: type/quizType/filters');
 		if (quizType !== type) {
 			dispatch(switchQuiz(quizType));
 		} else {
 			dispatch(loadQuizWithParameters(quizType, filters));
 		}
 	}, [quizType, type, filters, dispatch]);
+	const sessionEnd = currentSession.questionsRemaining === 0
 
 	const customOptions = (quizType === 'numbers') ? <CustomNumberOptions /> : <CustomVerbOptions />
 	return (
@@ -42,7 +42,7 @@ const QuizPage = (props) => {
 							<Row className="show-grid">
 								<Col md={7}>
 									<Row className="show-grid">
-										<ControlledCard type={quizType} filters={filters} quiz={quiz} user={user} dispatch={dispatch} />
+										<ControlledCard type={quizType} filters={filters} quiz={quiz} user={user} dispatch={dispatch} sessionEnd={sessionEnd} />
 									</Row>
 									<Row className="ctrl">
 										<LinkControls filters={filters} />
@@ -74,6 +74,7 @@ QuizPage.propTypes = {
 	user: PropTypes.object.isRequired,
 	filters: PropTypes.object.isRequired,
 	headerText: PropTypes.string.isRequired,
+	currentSession: PropTypes.object.isRequired,
 };
 
 export default QuizPage;

--- a/client/src/components/SessionEndCard.js
+++ b/client/src/components/SessionEndCard.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SessionEndCard = (props) => {
+
+}
+
+SessionEndCard.propTypes = {
+    metrics: PropTypes.object
+}
+
+SessionEndCard.defaultProps = {
+    metrics: {}
+}
+
+export default SessionEndCard;

--- a/client/src/components/SessionEndCard.js
+++ b/client/src/components/SessionEndCard.js
@@ -5,7 +5,7 @@ const SessionEndCard = (props) => {
     return (
         <section className="flashcard front">
             <div>
-                <b>Congrats on finishing!</b>
+                <b>Congrats on finishing the session!</b>
             </div>
         </section>
     )

--- a/client/src/components/SessionEndCard.js
+++ b/client/src/components/SessionEndCard.js
@@ -2,7 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 const SessionEndCard = (props) => {
-
+    return (
+        <section className="flashcard front">
+            <div>
+                <b>Congrats on finishing!</b>
+            </div>
+        </section>
+    )
 }
 
 SessionEndCard.propTypes = {

--- a/client/src/components/VerbQuizCard.js
+++ b/client/src/components/VerbQuizCard.js
@@ -74,7 +74,7 @@ VerbQuizCard.propTypes = {
 	text: PropTypes.string,
 	mood: PropTypes.string,
 	irregularity: PropTypes.string,
-	questionNum: PropTypes.number,
+	questionNum: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 	definition: PropTypes.string
 };
 

--- a/client/src/containers/LinkControls.js
+++ b/client/src/containers/LinkControls.js
@@ -1,25 +1,28 @@
 import { connect } from 'react-redux';
-import { nextQuestion, prevQuestion, flipCard, endSession } from '../actions';
+import { nextQuestion, prevQuestion, flipCard, endSession, startSession } from '../actions';
 import Controls from '../components/Controls';
+import {getIsLastQuestion, getIsFirstQuestion} from '../selectors/currentSession';
 
 const mapStateToProps = (state, ownProps) => ({
 	showAnswer: state.quiz.showAnswer,
 	filters: state.filter,
-	isLastQuestion: state.currentSession.isLastQuestion,
+	session: { ... state.currentSession, isFirstQuestionInSession: getIsFirstQuestion(state)},
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => {
-	const {filters, isLastQuestion} = ownProps;
-	console.log('!!!!')
 	console.log(ownProps);
-	console.log(isLastQuestion);
+	const { filters, session: { isSessionOver, isLastQuestionInSession }} = ownProps;
 
 	return({
 		onNextClick: () => {
-			if (isLastQuestion === true) {
-				console.log('LASTQUESTION');
+			if (isSessionOver) {
+				dispatch(startSession());
+				dispatch(nextQuestion(filters));
+			}
+			else if (isLastQuestionInSession === true) {
 				dispatch(endSession());
 			}
+		
 			else {
 				dispatch(nextQuestion(filters));
 			}

--- a/client/src/containers/LinkControls.js
+++ b/client/src/containers/LinkControls.js
@@ -1,12 +1,12 @@
 import { connect } from 'react-redux';
 import { nextQuestion, prevQuestion, flipCard, endSession, startSession } from '../actions';
 import Controls from '../components/Controls';
-import {getIsLastQuestion, getIsFirstQuestion} from '../selectors/currentSession';
+import { getIsFirstQuestion } from '../selectors/currentSession';
 
 const mapStateToProps = (state, ownProps) => ({
 	showAnswer: state.quiz.showAnswer,
 	filters: state.filter,
-	session: { ... state.currentSession, isFirstQuestionInSession: getIsFirstQuestion(state)},
+	session: { ...state.currentSession, isFirstQuestionInSession: getIsFirstQuestion(state)},
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => {

--- a/client/src/containers/LinkControls.js
+++ b/client/src/containers/LinkControls.js
@@ -4,7 +4,7 @@ import Controls from '../components/Controls';
 
 const mapStateToProps = (state, ownProps) => ({
 	showAnswer: state.quiz.showAnswer,
-	filters: state.filter
+	filters: state.filter,
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => {

--- a/client/src/containers/LinkControls.js
+++ b/client/src/containers/LinkControls.js
@@ -10,7 +10,6 @@ const mapStateToProps = (state, ownProps) => ({
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => {
-	console.log(ownProps);
 	const { filters, session: { isSessionOver, isLastQuestionInSession }} = ownProps;
 
 	return({

--- a/client/src/containers/LinkControls.js
+++ b/client/src/containers/LinkControls.js
@@ -1,17 +1,28 @@
 import { connect } from 'react-redux';
-import { nextQuestion, prevQuestion, flipCard } from '../actions';
+import { nextQuestion, prevQuestion, flipCard, endSession } from '../actions';
 import Controls from '../components/Controls';
 
 const mapStateToProps = (state, ownProps) => ({
 	showAnswer: state.quiz.showAnswer,
 	filters: state.filter,
+	isLastQuestion: state.currentSession.isLastQuestion,
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => {
-	const {filters} = ownProps;
+	const {filters, isLastQuestion} = ownProps;
+	console.log('!!!!')
+	console.log(ownProps);
+	console.log(isLastQuestion);
+
 	return({
 		onNextClick: () => {
-			dispatch(nextQuestion(filters));
+			if (isLastQuestion === true) {
+				console.log('LASTQUESTION');
+				dispatch(endSession());
+			}
+			else {
+				dispatch(nextQuestion(filters));
+			}
 		},
 		onPrevClick: () => {
 			dispatch(prevQuestion(filters));

--- a/client/src/containers/SessionLengthChoices.js
+++ b/client/src/containers/SessionLengthChoices.js
@@ -4,16 +4,15 @@ import {setSessionLength } from '../actions';
 import { Form, OverlayTrigger, Tooltip } from 'react-bootstrap';
 
 const SessionLengthChoices = ({sessionLength, onSelect}) => {
-
     return (
         <div>
             Session Length <br />
-            <Form.Check inline onChange={onSelect} label="None" value="-1" type="radio" checked={sessionLength == 0} />
-            <Form.Check inline onChange={onSelect} label="2" value="2" type="radio" checked={sessionLength == 2}/>
-            <Form.Check inline onChange={onSelect} label="10" value="10" type="radio" checked={sessionLength == 10}/>
-            <Form.Check inline onChange={onSelect} label="15" value="15" type="radio" checked={sessionLength == 15}/>
-            <Form.Check inline onChange={onSelect} label="20" value="20" type="radio" checked={sessionLength ==20 }/>
-            <Form.Check inline onChange={onSelect} label="25" value="25" type="radio" checked={sessionLength == 25}/>
+            <Form.Check inline onChange={onSelect} label="None" value="-1" type="radio" checked={sessionLength === -1} />
+            <Form.Check inline onChange={onSelect} label="2" value="2" type="radio" checked={sessionLength === 2}/>
+            <Form.Check inline onChange={onSelect} label="10" value="10" type="radio" checked={sessionLength === 10}/>
+            <Form.Check inline onChange={onSelect} label="15" value="15" type="radio" checked={sessionLength === 15}/>
+            <Form.Check inline onChange={onSelect} label="20" value="20" type="radio" checked={sessionLength === 20 }/>
+            <Form.Check inline onChange={onSelect} label="25" value="25" type="radio" checked={sessionLength === 25}/>
         </div>
     );
 }

--- a/client/src/containers/SessionLengthChoices.js
+++ b/client/src/containers/SessionLengthChoices.js
@@ -8,7 +8,6 @@ const SessionLengthChoices = ({sessionLength, onSelect}) => {
         <div>
             Session Length <br />
             <Form.Check inline onChange={onSelect} label="None" value="-1" type="radio" checked={sessionLength === -1} />
-            <Form.Check inline onChange={onSelect} label="2" value="2" type="radio" checked={sessionLength === 2}/>
             <Form.Check inline onChange={onSelect} label="10" value="10" type="radio" checked={sessionLength === 10}/>
             <Form.Check inline onChange={onSelect} label="15" value="15" type="radio" checked={sessionLength === 15}/>
             <Form.Check inline onChange={onSelect} label="20" value="20" type="radio" checked={sessionLength === 20 }/>

--- a/client/src/containers/SessionLengthChoices.js
+++ b/client/src/containers/SessionLengthChoices.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import {setSessionLength } from '../actions';
+import { Form, OverlayTrigger, Tooltip } from 'react-bootstrap';
+
+const SessionLengthChoices = ({sessionLength, onSelect}) => {
+
+    return (
+        <div>
+            Session Length <br />
+            <Form.Check inline onChange={onSelect} label="None" value="-1" type="radio" checked={sessionLength == 0} />
+            <Form.Check inline onChange={onSelect} label="2" value="2" type="radio" checked={sessionLength == 2}/>
+            <Form.Check inline onChange={onSelect} label="10" value="10" type="radio" checked={sessionLength == 10}/>
+            <Form.Check inline onChange={onSelect} label="15" value="15" type="radio" checked={sessionLength == 15}/>
+            <Form.Check inline onChange={onSelect} label="20" value="20" type="radio" checked={sessionLength ==20 }/>
+            <Form.Check inline onChange={onSelect} label="25" value="25" type="radio" checked={sessionLength == 25}/>
+        </div>
+    );
+}
+
+SessionLengthChoices.propTypes = {
+
+};
+
+const mapStateToProps = (state, ownProps) => ({
+    sessionLength: state.currentSession.sessionLength
+});
+
+const mapDispatchToProps = (dispatch, ownProps) => ({
+    onSelect: (e) => {
+        dispatch(setSessionLength(e.target.value));
+    }
+});
+
+
+export default connect(
+    mapStateToProps,
+    mapDispatchToProps
+)(SessionLengthChoices);
+

--- a/client/src/containers/SessionLengthChoices.js
+++ b/client/src/containers/SessionLengthChoices.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import {setSessionLength } from '../actions';
-import { Form, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { Form } from 'react-bootstrap';
 
 const SessionLengthChoices = ({sessionLength, onSelect}) => {
     return (
@@ -30,7 +30,6 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
         dispatch(setSessionLength(e.target.value));
     }
 });
-
 
 export default connect(
     mapStateToProps,

--- a/client/src/reducers/currentSession.js
+++ b/client/src/reducers/currentSession.js
@@ -1,25 +1,29 @@
 import {
-    START_SESSION, SET_SESSION_LENGTH
+    START_SESSION, SET_SESSION_LENGTH, NEXT_QUESTION
 } from '../actions';
 
 const initialState = {
     date: '',
-    currentCardCount: 0,
     sessionInProgress: false,
-    sessionLength: 0
+    sessionLength: 0,
+    questionsRemaining: -1
 };
 
 const currentSession = (state=initialState, action) => {
     switch (action.type) {
         case START_SESSION: {
             const {sessionLength} = action;
-            return { ...state, date: Date.now.parse(),
-            sessionInProgress: true
+            return { ...state, date: Date(Date.now()).toString(),
+            sessionInProgress: true,
+            questionsRemaining: parseInt(sessionLength)
             };
         };
         case SET_SESSION_LENGTH: {
             const {sessionLength} = action;
-            return { ...state, sessionLength: sessionLength}
+            return { ...state, sessionLength: parseInt(sessionLength)}
+        }
+        case NEXT_QUESTION: {
+            return {...state, questionsRemaining: state.questionsRemaining-1}
         }
         default: {
             return state;

--- a/client/src/reducers/currentSession.js
+++ b/client/src/reducers/currentSession.js
@@ -1,12 +1,14 @@
 import {
-    START_SESSION, SET_SESSION_LENGTH, NEXT_QUESTION
+    START_SESSION, SET_SESSION_LENGTH, NEXT_QUESTION, END_SESSION
 } from '../actions';
 
 const initialState = {
     date: '',
     sessionInProgress: false,
     sessionLength: 0,
-    questionsRemaining: -1
+    questionsRemaining: -1,
+    isLastQuestion: false,
+    sessionOver: false,
 };
 
 const currentSession = (state=initialState, action) => {
@@ -15,7 +17,8 @@ const currentSession = (state=initialState, action) => {
             const {sessionLength} = action;
             return { ...state, date: Date(Date.now()).toString(),
             sessionInProgress: true,
-            questionsRemaining: parseInt(sessionLength)
+            questionsRemaining: parseInt(sessionLength),
+            lastQuestion: false
             };
         };
         case SET_SESSION_LENGTH: {
@@ -23,7 +26,12 @@ const currentSession = (state=initialState, action) => {
             return { ...state, sessionLength: parseInt(sessionLength)}
         }
         case NEXT_QUESTION: {
-            return {...state, questionsRemaining: state.questionsRemaining-1}
+            const questionsRemaining = state.questionsRemaining -1;
+            const isLastQuestion = questionsRemaining === 0 ? true : false;
+            return { ...state, questionsRemaining: questionsRemaining, isLastQuestion: isLastQuestion}
+        }
+        case END_SESSION: {
+            return  { ... initialState, sessionOver: true}
         }
         default: {
             return state;

--- a/client/src/reducers/currentSession.js
+++ b/client/src/reducers/currentSession.js
@@ -1,0 +1,30 @@
+import {
+    START_SESSION, SET_SESSION_LENGTH
+} from '../actions';
+
+const initialState = {
+    date: '',
+    currentCardCount: 0,
+    sessionInProgress: false,
+    sessionLength: 0
+};
+
+const currentSession = (state=initialState, action) => {
+    switch (action.type) {
+        case START_SESSION: {
+            const {sessionLength} = action;
+            return { ...state, date: Date.now.parse(),
+            sessionInProgress: true
+            };
+        };
+        case SET_SESSION_LENGTH: {
+            const {sessionLength} = action;
+            return { ...state, sessionLength: sessionLength}
+        }
+        default: {
+            return state;
+        }
+    }
+}
+
+export default currentSession;

--- a/client/src/reducers/currentSession.js
+++ b/client/src/reducers/currentSession.js
@@ -1,7 +1,6 @@
 import {
     START_SESSION, SET_SESSION_LENGTH, NEXT_QUESTION, END_SESSION, PREV_QUESTION
 } from '../actions';
-import { getIsSessionEnabled } from '../selectors/currentSession';
 
 const initialState = {
     date: '',
@@ -13,14 +12,11 @@ const initialState = {
 const currentSession = (state=initialState, action) => {
     switch (action.type) {
         case START_SESSION: {
-            return { ...state, 
-                    date: Date(Date.now()).toString(),
-                    sessionQuestionNum: 0,
-            };
-        };
+            return { ...state, date: Date.now().toString(), sessionQuestionNum: 0}
+        }
         case SET_SESSION_LENGTH: {
             const {sessionLength} = action;
-            const isSessionEnabled = true ? sessionLength!="-1" : false;
+            const isSessionEnabled = true ? sessionLength!=="-1" : false;
             return { ...state, sessionLength: parseInt(sessionLength), isSessionEnabled: isSessionEnabled}
         }
         case PREV_QUESTION: {
@@ -32,7 +28,7 @@ const currentSession = (state=initialState, action) => {
             return { ...state, sessionQuestionNum: questionNum }
         }
         case END_SESSION: {
-            return  { ... state, sessionQuestionNum: state.sessionLength+2 }
+            return  { ...state, sessionQuestionNum: state.sessionLength+2 }
         }
         default: {
             return state;

--- a/client/src/reducers/currentSession.js
+++ b/client/src/reducers/currentSession.js
@@ -1,37 +1,38 @@
 import {
-    START_SESSION, SET_SESSION_LENGTH, NEXT_QUESTION, END_SESSION
+    START_SESSION, SET_SESSION_LENGTH, NEXT_QUESTION, END_SESSION, PREV_QUESTION
 } from '../actions';
+import { getIsSessionEnabled } from '../selectors/currentSession';
 
 const initialState = {
     date: '',
-    sessionInProgress: false,
-    sessionLength: 0,
-    questionsRemaining: -1,
-    isLastQuestion: false,
-    sessionOver: false,
+    sessionLength: 10,
+    isSessionEnabled: true,
+    sessionQuestionNum: -1
 };
 
 const currentSession = (state=initialState, action) => {
     switch (action.type) {
         case START_SESSION: {
-            const {sessionLength} = action;
-            return { ...state, date: Date(Date.now()).toString(),
-            sessionInProgress: true,
-            questionsRemaining: parseInt(sessionLength),
-            lastQuestion: false
+            return { ...state, 
+                    date: Date(Date.now()).toString(),
+                    sessionQuestionNum: 0,
             };
         };
         case SET_SESSION_LENGTH: {
             const {sessionLength} = action;
-            return { ...state, sessionLength: parseInt(sessionLength)}
+            const isSessionEnabled = true ? sessionLength!="-1" : false;
+            return { ...state, sessionLength: parseInt(sessionLength), isSessionEnabled: isSessionEnabled}
+        }
+        case PREV_QUESTION: {
+            const questionNum = state.sessionQuestionNum -1;
+            return { ...state, sessionQuestionNum: questionNum }
         }
         case NEXT_QUESTION: {
-            const questionsRemaining = state.questionsRemaining -1;
-            const isLastQuestion = questionsRemaining === 0 ? true : false;
-            return { ...state, questionsRemaining: questionsRemaining, isLastQuestion: isLastQuestion}
+            const questionNum = state.sessionQuestionNum +1;
+            return { ...state, sessionQuestionNum: questionNum }
         }
         case END_SESSION: {
-            return  { ... initialState, sessionOver: true}
+            return  { ... state, sessionQuestionNum: state.sessionLength+2 }
         }
         default: {
             return state;

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -1,4 +1,5 @@
 import { combineReducers } from 'redux';
+import currentSession from './currentSession';
 import filters from './filters';
 import quiz from './quiz';
 import user from './user';
@@ -6,6 +7,7 @@ import user from './user';
 const practicar = combineReducers({
 	filters,
 	quiz,
+	currentSession,
 	user
 });
 

--- a/client/src/reducers/quiz.js
+++ b/client/src/reducers/quiz.js
@@ -174,6 +174,7 @@ const quiz = (state = initialState, action) => {
 	//TODO: Generalize and put attributes in current question slice
 	case NEXT_QUESTION: {
 		const {questions} = state;
+		
 		const {filters} = action;
 		if (questions.length === 0) {
 			console.error('cannot fetch next question, questions not loaded');

--- a/client/src/reducers/quiz.js
+++ b/client/src/reducers/quiz.js
@@ -1,6 +1,6 @@
 import {
 	NEXT_QUESTION, PREV_QUESTION, FLIP_CARD, SUBMIT_ANSWER, LOAD_QUIZ,
-	LOAD_QUIZ_SUCCESS, LOAD_QUIZ_ERROR, SET_FILTER, TOGGLE_FOCUS, SET_VERBSET
+	LOAD_QUIZ_SUCCESS, LOAD_QUIZ_ERROR, SET_FILTER, TOGGLE_FOCUS, SET_VERBSET, SET_SESSION_LENGTH
 } from '../actions';
 
 // TODO: move this
@@ -161,6 +161,7 @@ const initialState = {
 	hasSubmittedAnswer: false,
 	questionSequence: [],
 	sequenceIndex: -1,
+	sessionLength: -1, 
 	focus: 'card',
 	verbSet: 'topHundred',
 	type: '',
@@ -314,6 +315,11 @@ const quiz = (state = initialState, action) => {
 			};
 			newState[action.filter] = action.status;
 			return newState;
+		}
+		case SET_SESSION_LENGTH: {
+			return {
+				...state,
+				sessionLength: action.sessionLength};
 		}
 		case TOGGLE_FOCUS: {
 			const newState = {

--- a/client/src/selectors/currentSession.js
+++ b/client/src/selectors/currentSession.js
@@ -1,0 +1,8 @@
+import { createSelector } from 'reselect';
+
+export const getNumQuestionsRemaining = state => state.currentSession.sessionLength - state.currentSession.sessionQuestionNum; 
+export const getIsSessionEnabled = state => state.currentSession.isSessionEnabled;
+export const getSessionQuestionNum = state => state.currentSession.sessionQuestionNum;
+export const getIsFirstQuestion = createSelector(getIsSessionEnabled, getSessionQuestionNum,  (isSessionEnabled, sessionQuestionNum) => isSessionEnabled && sessionQuestionNum === 1); 
+export const getIsLastQuestion = createSelector(getIsSessionEnabled, getNumQuestionsRemaining, (isSessionEnabled, questionsRemaining) => isSessionEnabled && questionsRemaining === 0);
+export const getIsSessionOver = createSelector(getIsSessionEnabled, getNumQuestionsRemaining, (isSessionEnabled, questionsRemaining) => isSessionEnabled && questionsRemaining < 0);

--- a/client/src/selectors/currentSession.js
+++ b/client/src/selectors/currentSession.js
@@ -5,4 +5,4 @@ export const getIsSessionEnabled = state => state.currentSession.isSessionEnable
 export const getSessionQuestionNum = state => state.currentSession.sessionQuestionNum;
 export const getIsFirstQuestion = createSelector(getIsSessionEnabled, getSessionQuestionNum,  (isSessionEnabled, sessionQuestionNum) => isSessionEnabled && sessionQuestionNum === 1); 
 export const getIsLastQuestion = createSelector(getIsSessionEnabled, getNumQuestionsRemaining, (isSessionEnabled, questionsRemaining) => isSessionEnabled && questionsRemaining === 0);
-export const getIsSessionOver = createSelector(getIsSessionEnabled, getNumQuestionsRemaining, (isSessionEnabled, questionsRemaining) => isSessionEnabled && questionsRemaining < 0);
+export const getIsSessionOver = createSelector(getIsSessionEnabled, getNumQuestionsRemaining, getSessionQuestionNum, (isSessionEnabled, questionsRemaining) => isSessionEnabled && questionsRemaining < 0);

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -19,7 +19,7 @@ middlewares.push(thunk);
 const persistConfig = {
   key: 'root',
   storage,
-  blacklist: ['filters']
+  blacklist: ['filters', 'quiz', 'currentSession']
 };
 
 const persistedReducer = persistReducer(persistConfig, rootReducer);


### PR DESCRIPTION
This PR adds sessions to the Redux state and UI choices for selecting length of a session.

- In a session, the number is # questions done / # total questions
- When a user has gone through all of the questions in a session, they get a congratulatory message. This will be soon replaced with a score of # questions answered correctly.
- After starting a new session, you can't go back to an old session
- User can dynamically change the session length. Currently, if you choose a lower length than your current question #, it ends the session

Next steps

- Persist session to user history after session finishes
- Define state slice for storing metrics about a session
- Simple index page showing session history